### PR TITLE
Use Unity's Vector2.Scale

### DIFF
--- a/Assets/Dependencies/DanmakU/_Core_/Danmaku.cs
+++ b/Assets/Dependencies/DanmakU/_Core_/Danmaku.cs
@@ -430,7 +430,7 @@ namespace Hourai.DanmakU {
             get { return colliderOffset; }
             set
             {
-                colliderOffset = prefab.cachedScale.Hadamard2(value);
+                colliderOffset = Vector2.Scale(prefab.cachedScale, value);
             }
         }
 

--- a/Assets/Dependencies/DanmakU/_Core_/DanmakuPrefab.cs
+++ b/Assets/Dependencies/DanmakU/_Core_/DanmakuPrefab.cs
@@ -514,7 +514,7 @@ namespace Hourai.DanmakU {
                         break;
                 }
                 danmaku.sizeSquared = colliderSize.y * colliderSize.y;
-                danmaku.colliderOffset = cachedScale.Hadamard2(colliderOffset);
+                danmaku.colliderOffset = Vector2.Scale(cachedScale, colliderOffset);
             }
 
             danmaku.Color = type.Color;


### PR DESCRIPTION
When cloning this repository, these two calls to the extension method "Vector2.Hadamard2" created compilation errors. Since they do exactly the same as [Vector2.Scale](https://github.com/MattRix/UnityDecompiled/blob/master/UnityEngine/UnityEngine/Vector2.cs#L164) anyway, this update replaces the calls.