### PR TITLE
Fix for render bug when disabling emitters

### DIFF
--- a/Assets/DanmakU/Runtime/Colliders/TeamCollider.cs
+++ b/Assets/DanmakU/Runtime/Colliders/TeamCollider.cs
@@ -7,23 +7,10 @@ namespace DanmakU
     public class TeamCollider : MonoBehaviour
     {
         public DanmakuCollider Collider;
-        DanmakuEmitter emitter;
+        public int TeamNo;
 
         //todo: make a thorough pass focusing on accessibility
         //todo: thorough update to danmaku
-
-        ///How much time this unit has left invulnerable
-        //private float invulnTimer = 0f;
-        //How much health this unit is capable of at perfect condition
-        public int maxHealth;
-
-        //How much health this unit currently contains
-        private int curHealth;
-
-        void OnStart()
-        {
-            curHealth = maxHealth;
-        }
 
         /// <summary>
         /// This function is called when the object becomes enabled and active.
@@ -35,8 +22,6 @@ namespace DanmakU
                 Debug.Log("Subscribed");
                 Collider.OnDanmakuCollision += OnDanmakuCollision;
             }
-
-            emitter = GetComponent<DanmakuEmitter>();
         }
 
         /// <summary>
@@ -50,35 +35,21 @@ namespace DanmakU
             }
         }
 
-
-        void takeDamage(int amount_damage)
+        void getHit()
         {
-            curHealth -= amount_damage;
+            gameObject.SetActive(false);
         }
 
-        // Update is called once per frame
-        // void Update()
-        // {
-        /*if (invulnTimer > 0f)
-        {
-          invulnTimer -= Time.deltaTime;
-          if (invulnTimer < 0f)
-          {
-            invulnTimer = 0f;
-            //sprite.color = Color.white;
-          }
-        }*/
-        // }
 
         void OnDanmakuCollision(DanmakuCollisionList collisions)
         {
             //if (emitter)
             foreach (var collision in collisions)
             {
-                if (collision.Danmaku.Pool.TeamNo != emitter.set.Pool.TeamNo)
+                if (collision.Danmaku.Pool.TeamNo != TeamNo)
                 {
                     collision.Danmaku.Destroy();
-                    takeDamage(collision.Danmaku.Pool.Damage);
+                    getHit();
                 }
             }
         }

--- a/Assets/DanmakU/Runtime/Colliders/TeamCollider.cs
+++ b/Assets/DanmakU/Runtime/Colliders/TeamCollider.cs
@@ -4,94 +4,92 @@ using UnityEngine;
 
 namespace DanmakU
 {
-
-  public class TeamCollider : MonoBehaviour
-  {
-
-    public DanmakuCollider Collider;
-    DanmakuEmitter emitter;
-
-    //todo: make a thorough pass focusing on accessibility
-    //todo: thorough update to danmaku
-    
-    ///How much time this unit has left invulnerable
-    //private float invulnTimer = 0f;
-    //How much health this unit is capable of at perfect condition
-    public int maxHealth;
-    //How much health this unit currently contains
-    private int curHealth;
-
-    void OnStart()
+    public class TeamCollider : MonoBehaviour
     {
-      curHealth = maxHealth;
-    }
+        public DanmakuCollider Collider;
+        DanmakuEmitter emitter;
 
-    /// <summary>
-    /// This function is called when the object becomes enabled and active.
-    /// </summary>
-    void OnEnable()
-    {
-      if (Collider != null)
-      {
-        Debug.Log("Subscribed");
-        Collider.OnDanmakuCollision += OnDanmakuCollision;
-      }
-      emitter = GetComponent<DanmakuEmitter>();
-    }
+        //todo: make a thorough pass focusing on accessibility
+        //todo: thorough update to danmaku
 
-    /// <summary>
-    /// This function is called when the behaviour becomes disabled or inactive.
-    /// </summary>
-    void OnDisable()
-    {
-      if (Collider != null)
-      {
-        Collider.OnDanmakuCollision -= OnDanmakuCollision;
-      }
-    }
+        ///How much time this unit has left invulnerable
+        //private float invulnTimer = 0f;
+        //How much health this unit is capable of at perfect condition
+        public int maxHealth;
 
+        //How much health this unit currently contains
+        private int curHealth;
 
-    void takeDamage(int amount_damage)
-    {
-      curHealth -= amount_damage;
-    }
-
-    // Update is called once per frame
-    // void Update()
-    // {
-    /*if (invulnTimer > 0f)
-    {
-      invulnTimer -= Time.deltaTime;
-      if (invulnTimer < 0f)
-      {
-        invulnTimer = 0f;
-        //sprite.color = Color.white;
-      }
-    }*/
-    // }
-
-    void OnDanmakuCollision(DanmakuCollisionList collisions)
-    {
-      //if (emitter)
-      foreach (var collision in collisions)
-      {
-        if (collision.Danmaku.Pool.TeamNo != emitter.set.Pool.TeamNo)
+        void OnStart()
         {
-          collision.Danmaku.Destroy();
-          takeDamage(collision.Danmaku.Pool.Damage);
+            curHealth = maxHealth;
         }
-      }
+
+        /// <summary>
+        /// This function is called when the object becomes enabled and active.
+        /// </summary>
+        void OnEnable()
+        {
+            if (Collider != null)
+            {
+                Debug.Log("Subscribed");
+                Collider.OnDanmakuCollision += OnDanmakuCollision;
+            }
+
+            emitter = GetComponent<DanmakuEmitter>();
+        }
+
+        /// <summary>
+        /// This function is called when the behaviour becomes disabled or inactive.
+        /// </summary>
+        void OnDisable()
+        {
+            if (Collider != null)
+            {
+                Collider.OnDanmakuCollision -= OnDanmakuCollision;
+            }
+        }
+
+
+        void takeDamage(int amount_damage)
+        {
+            curHealth -= amount_damage;
+        }
+
+        // Update is called once per frame
+        // void Update()
+        // {
+        /*if (invulnTimer > 0f)
+        {
+          invulnTimer -= Time.deltaTime;
+          if (invulnTimer < 0f)
+          {
+            invulnTimer = 0f;
+            //sprite.color = Color.white;
+          }
+        }*/
+        // }
+
+        void OnDanmakuCollision(DanmakuCollisionList collisions)
+        {
+            //if (emitter)
+            foreach (var collision in collisions)
+            {
+                if (collision.Danmaku.Pool.TeamNo != emitter.set.Pool.TeamNo)
+                {
+                    collision.Danmaku.Destroy();
+                    takeDamage(collision.Danmaku.Pool.Damage);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Reset is called when the user hits the Reset button in the Inspector's
+        /// context menu or when adding the component the first time.
+        /// </summary>
+        void Reset()
+        {
+            Collider = GetComponent<DanmakuCollider>();
+        }
     }
-
-    /// <summary>
-    /// Reset is called when the user hits the Reset button in the Inspector's
-    /// context menu or when adding the component the first time.
-    /// </summary>
-    void Reset()
-    {
-      Collider = GetComponent<DanmakuCollider>();
-    }
-
-  }
-
 }

--- a/Assets/DanmakU/Runtime/Colliders/TeamCollider.cs
+++ b/Assets/DanmakU/Runtime/Colliders/TeamCollider.cs
@@ -1,0 +1,97 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace DanmakU
+{
+
+  public class TeamCollider : MonoBehaviour
+  {
+
+    public DanmakuCollider Collider;
+    DanmakuEmitter emitter;
+
+    //todo: make a thorough pass focusing on accessibility
+    //todo: thorough update to danmaku
+    
+    ///How much time this unit has left invulnerable
+    //private float invulnTimer = 0f;
+    //How much health this unit is capable of at perfect condition
+    public int maxHealth;
+    //How much health this unit currently contains
+    private int curHealth;
+
+    void OnStart()
+    {
+      curHealth = maxHealth;
+    }
+
+    /// <summary>
+    /// This function is called when the object becomes enabled and active.
+    /// </summary>
+    void OnEnable()
+    {
+      if (Collider != null)
+      {
+        Debug.Log("Subscribed");
+        Collider.OnDanmakuCollision += OnDanmakuCollision;
+      }
+      emitter = GetComponent<DanmakuEmitter>();
+    }
+
+    /// <summary>
+    /// This function is called when the behaviour becomes disabled or inactive.
+    /// </summary>
+    void OnDisable()
+    {
+      if (Collider != null)
+      {
+        Collider.OnDanmakuCollision -= OnDanmakuCollision;
+      }
+    }
+
+
+    void takeDamage(int amount_damage)
+    {
+      curHealth -= amount_damage;
+    }
+
+    // Update is called once per frame
+    // void Update()
+    // {
+    /*if (invulnTimer > 0f)
+    {
+      invulnTimer -= Time.deltaTime;
+      if (invulnTimer < 0f)
+      {
+        invulnTimer = 0f;
+        //sprite.color = Color.white;
+      }
+    }*/
+    // }
+
+    void OnDanmakuCollision(DanmakuCollisionList collisions)
+    {
+      //if (emitter)
+      foreach (var collision in collisions)
+      {
+        if (collision.Danmaku.Pool.TeamNo != emitter.set.Pool.TeamNo)
+        {
+          collision.Danmaku.Destroy();
+          takeDamage(collision.Danmaku.Pool.Damage);
+        }
+      }
+    }
+
+    /// <summary>
+    /// Reset is called when the user hits the Reset button in the Inspector's
+    /// context menu or when adding the component the first time.
+    /// </summary>
+    void Reset()
+    {
+      Collider = GetComponent<DanmakuCollider>();
+    }
+
+  }
+
+}

--- a/Assets/DanmakU/Runtime/Core/DanmakuPool.cs
+++ b/Assets/DanmakU/Runtime/Core/DanmakuPool.cs
@@ -99,8 +99,6 @@ namespace DanmakU
 
         public int TeamNo { get; set; }
 
-        public int Damage { get; set; }
-
         /// <summary>
         /// The radius of the collider used to calculate collisions with the bullets in the pool.
         /// </summary>

--- a/Assets/DanmakU/Runtime/Core/DanmakuPool.cs
+++ b/Assets/DanmakU/Runtime/Core/DanmakuPool.cs
@@ -6,299 +6,328 @@ using Unity.Collections;
 using UnityEngine;
 using System.Runtime.CompilerServices;
 
-namespace DanmakU {
+namespace DanmakU
+{
+    /// <summary>
+    /// A pool of <see cref="DanmakU.Danmaku"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// DanmakuPools manage the lifetimes and data of all of the the bullets they own. Creation of a bullet
+    /// requires calling <see cref="Get"/> and calling <see cref="DanmakU.Danmaku.Destroy"/> returns its data
+    /// to the pool.
+    /// </para>
+    /// <para>
+    /// As more Danmaku are created from the pool, the amount of unused capacity will shrink. 
+    /// If more bullets are requested than there is <see cref="Capacity"/>, the pool will be resized. 
+    /// This can be an expensive operation, especially on already large pools. Ensuring bullets are 
+    /// timely destroyed and returned to the pool can remedy this.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// Implemented as a Structure of Arrays, DanmakuPools see two main modes of use: as a backing store of 
+    /// NativeArrays for Unity Jobs, and as an enumerable container for the managed bullets. The internal backing
+    /// arrays are exposed as fields to use in Unity Jobs:
+    /// <code>
+    /// using Unity.Jobs;
+    /// 
+    /// public struct CustomMoveDanmaku : IJobParallelFor {
+    ///   public Vector2 Movement;
+    ///   public NativeArray&lt;Vector2&gt; Positions;
+    /// 
+    ///   public void Execute(int index) {
+    ///     Positions[index] += Movement;
+    ///   }
+    /// }  
+    /// 
+    /// void ProcessDanmakU(DanmakuPool pool) {
+    ///   new CustomMoveDanmaku {
+    ///     Movement = Vector2.up,
+    ///     Positions = pool.Positions
+    ///   }.Schedule();
+    /// }
+    /// </code>
+    /// </example>
+    /// <example>
+    /// The pool implements `IEnumerable&lt;Danmaku&gt; and can be used in `foreach` loops to iterate over 
+    /// all of the bullets in the pool. This does not generate any garbage when used directly with the pool as 
+    /// the enumerator returned is a mutable struct enumerator.
+    /// <code>
+    /// void ProcessPool(DanmakuPool pool) {
+    ///   foreach (Danmaku danmaku in pool) {
+    ///     // Move every bullet to the right.
+    ///     danmaku.Position += Vector2.right;
+    ///   }
+    /// }
+    /// </code>
+    /// </example>
+    /// <example>
+    /// This also makes it compatible with LINQ queries. However this is discouraged as the need to box
+    /// the enumerator as an enumerable generates garbage.
+    /// <code>
+    /// using System.Linq;
+    /// 
+    /// void ProcessPool(DanmakuPool pool) {
+    ///   // Get all of the bullets older than 5 seconds
+    ///   var oldDanmaku = pool.Where(danmaku => danmaku.Time > 5f);
+    ///   // Destroy them
+    ///   foreach (var bullet in oldDanmaku) {
+    ///     bullet.Destroy(); 
+    ///   }
+    /// }
+    /// </code>
+    /// </example>
+    public class DanmakuPool : IEnumerable<Danmaku>, IDisposable
+    {
+        /// <summary>
+        /// The recommended batch size for processing Danmaku in parallelizable jobs.
+        /// </summary>
+        /// <seealso cref="Unity.Jobs.IJobParallelFor"/>
+        public const int kBatchSize = 1024;
 
-/// <summary>
-/// A pool of <see cref="DanmakU.Danmaku"/>.
-/// </summary>
-/// <remarks>
-/// <para>
-/// DanmakuPools manage the lifetimes and data of all of the the bullets they own. Creation of a bullet
-/// requires calling <see cref="Get"/> and calling <see cref="DanmakU.Danmaku.Destroy"/> returns its data
-/// to the pool.
-/// </para>
-/// <para>
-/// As more Danmaku are created from the pool, the amount of unused capacity will shrink. 
-/// If more bullets are requested than there is <see cref="Capacity"/>, the pool will be resized. 
-/// This can be an expensive operation, especially on already large pools. Ensuring bullets are 
-/// timely destroyed and returned to the pool can remedy this.
-/// </para>
-/// </remarks>
-/// <example>
-/// Implemented as a Structure of Arrays, DanmakuPools see two main modes of use: as a backing store of 
-/// NativeArrays for Unity Jobs, and as an enumerable container for the managed bullets. The internal backing
-/// arrays are exposed as fields to use in Unity Jobs:
-/// <code>
-/// using Unity.Jobs;
-/// 
-/// public struct CustomMoveDanmaku : IJobParallelFor {
-///   public Vector2 Movement;
-///   public NativeArray&lt;Vector2&gt; Positions;
-/// 
-///   public void Execute(int index) {
-///     Positions[index] += Movement;
-///   }
-/// }  
-/// 
-/// void ProcessDanmakU(DanmakuPool pool) {
-///   new CustomMoveDanmaku {
-///     Movement = Vector2.up,
-///     Positions = pool.Positions
-///   }.Schedule();
-/// }
-/// </code>
-/// </example>
-/// <example>
-/// The pool implements `IEnumerable&lt;Danmaku&gt; and can be used in `foreach` loops to iterate over 
-/// all of the bullets in the pool. This does not generate any garbage when used directly with the pool as 
-/// the enumerator returned is a mutable struct enumerator.
-/// <code>
-/// void ProcessPool(DanmakuPool pool) {
-///   foreach (Danmaku danmaku in pool) {
-///     // Move every bullet to the right.
-///     danmaku.Position += Vector2.right;
-///   }
-/// }
-/// </code>
-/// </example>
-/// <example>
-/// This also makes it compatible with LINQ queries. However this is discouraged as the need to box
-/// the enumerator as an enumerable generates garbage.
-/// <code>
-/// using System.Linq;
-/// 
-/// void ProcessPool(DanmakuPool pool) {
-///   // Get all of the bullets older than 5 seconds
-///   var oldDanmaku = pool.Where(danmaku => danmaku.Time > 5f);
-///   // Destroy them
-///   foreach (var bullet in oldDanmaku) {
-///     bullet.Destroy(); 
-///   }
-/// }
-/// </code>
-/// </example>
-public class DanmakuPool : IEnumerable<Danmaku>, IDisposable {
+        const int kGrowthFactor = 2;
 
-  /// <summary>
-  /// The recommended batch size for processing Danmaku in parallelizable jobs.
-  /// </summary>
-  /// <seealso cref="Unity.Jobs.IJobParallelFor"/>
-  public const int kBatchSize = 1024;
-  const int kGrowthFactor = 2;
+        /// <summary>
+        /// Gets the total count of active bullets currently managed by the pool.
+        /// </summary>
+        public int ActiveCount => activeCountArray[0];
 
-  /// <summary>
-  /// Gets the total count of active bullets currently managed by the pool.
-  /// </summary>
-  public int ActiveCount => activeCountArray[0];
+        /// <summary>
+        /// Gets the total capacity of the pool. Strictly greater than or equal to <see cref="ActiveCount"/>.
+        /// </summary>
+        public int Capacity { get; private set; }
 
-  /// <summary>
-  /// Gets the total capacity of the pool. Strictly greater than or equal to <see cref="ActiveCount"/>.
-  /// </summary>
-  public int Capacity { get; private set; }
+        public int TeamNo { get; set; }
 
-    public int TeamNo { get; set; }
+        public int Damage { get; set; }
 
-    public int Damage { get; set; }
+        /// <summary>
+        /// The radius of the collider used to calculate collisions with the bullets in the pool.
+        /// </summary>
+        public float ColliderRadius;
 
-  /// <summary>
-  /// The radius of the collider used to calculate collisions with the bullets in the pool.
-  /// </summary>
-  public float ColliderRadius;
+        internal NativeArray<float> Times;
+        internal NativeArray<DanmakuState> InitialStates;
 
-  internal NativeArray<float> Times;
-  internal NativeArray<DanmakuState> InitialStates;
+        /// <summary>
+        /// The array of all world positions of <see cref="DanmakU.Danmaku"/> in the pool.
+        /// </summary>
+        /// <seealso cref="DanmakU.Danmaku.Position"/>
+        public NativeArray<Vector2> Positions;
 
-  /// <summary>
-  /// The array of all world positions of <see cref="DanmakU.Danmaku"/> in the pool.
-  /// </summary>
-  /// <seealso cref="DanmakU.Danmaku.Position"/>
-  public NativeArray<Vector2> Positions;
+        /// <summary>
+        /// The array of all rotations of <see cref="DanmakU.Danmaku"/> in the pool.
+        /// </summary>
+        /// <seealso cref="DanmakU.Danmaku.Rotation"/>
+        public NativeArray<float> Rotations;
 
-  /// <summary>
-  /// The array of all rotations of <see cref="DanmakU.Danmaku"/> in the pool.
-  /// </summary>
-  /// <seealso cref="DanmakU.Danmaku.Rotation"/>
-  public NativeArray<float> Rotations;
+        /// <summary>
+        /// The array of all speeds of <see cref="DanmakU.Danmaku"/> in the pool.
+        /// </summary>
+        /// <seealso cref="DanmakU.Danmaku.Speed"/>
+        public NativeArray<float> Speeds;
 
-  /// <summary>
-  /// The array of all speeds of <see cref="DanmakU.Danmaku"/> in the pool.
-  /// </summary>
-  /// <seealso cref="DanmakU.Danmaku.Speed"/>
-  public NativeArray<float> Speeds;
+        /// <summary>
+        /// The array of all angular speeds of <see cref="DanmakU.Danmaku"/> in the pool.
+        /// </summary>
+        /// <seealso cref="DanmakU.Danmaku.AngularSpeed"/>
+        public NativeArray<float> AngularSpeeds;
 
-  /// <summary>
-  /// The array of all angular speeds of <see cref="DanmakU.Danmaku"/> in the pool.
-  /// </summary>
-  /// <seealso cref="DanmakU.Danmaku.AngularSpeed"/>
-  public NativeArray<float> AngularSpeeds;
+        /// <summary>
+        /// The array of all angular speeds of <see cref="DanmakU.Danmaku"/> in the pool.
+        /// </summary>
+        /// <remarks>
+        /// For performance reasons, the RGBA colors are stored as Vector4s.
+        /// </remarks>
+        /// <seealso cref="DanmakU.Danmaku.AngularSpeed"/>
+        public NativeArray<Vector4> Colors;
 
-  /// <summary>
-  /// The array of all angular speeds of <see cref="DanmakU.Danmaku"/> in the pool.
-  /// </summary>
-  /// <remarks>
-  /// For performance reasons, the RGBA colors are stored as Vector4s.
-  /// </remarks>
-  /// <seealso cref="DanmakU.Danmaku.AngularSpeed"/>
-  public NativeArray<Vector4> Colors;
+        internal NativeArray<int> activeCountArray;
+        internal NativeArray<Vector2> OldPositions;
+        internal NativeArray<int> CollisionMasks;
 
-  internal NativeArray<int> activeCountArray;
-  internal NativeArray<Vector2> OldPositions;
-  internal NativeArray<int> CollisionMasks;
+        internal DanmakuPool(int poolSize)
+        {
+            activeCountArray = new NativeArray<int>(1, Allocator.Persistent);
+            Capacity = poolSize;
+            InitialStates =
+                new NativeArray<DanmakuState>(poolSize, Allocator.Persistent, NativeArrayOptions.UninitializedMemory);
+            Times = new NativeArray<float>(poolSize, Allocator.Persistent, NativeArrayOptions.UninitializedMemory);
+            Positions = new NativeArray<Vector2>(poolSize, Allocator.Persistent,
+                NativeArrayOptions.UninitializedMemory);
+            Rotations = new NativeArray<float>(poolSize, Allocator.Persistent, NativeArrayOptions.UninitializedMemory);
+            Speeds = new NativeArray<float>(poolSize, Allocator.Persistent, NativeArrayOptions.UninitializedMemory);
+            AngularSpeeds =
+                new NativeArray<float>(poolSize, Allocator.Persistent, NativeArrayOptions.UninitializedMemory);
+            Colors = new NativeArray<Vector4>(poolSize, Allocator.Persistent, NativeArrayOptions.UninitializedMemory);
+            OldPositions =
+                new NativeArray<Vector2>(poolSize, Allocator.Persistent, NativeArrayOptions.UninitializedMemory);
+            CollisionMasks =
+                new NativeArray<int>(poolSize, Allocator.Persistent, NativeArrayOptions.UninitializedMemory);
+        }
 
-  internal DanmakuPool(int poolSize) {
-    activeCountArray = new NativeArray<int>(1, Allocator.Persistent);
-    Capacity = poolSize;
-    InitialStates = new NativeArray<DanmakuState>(poolSize, Allocator.Persistent, NativeArrayOptions.UninitializedMemory);
-    Times = new NativeArray<float>(poolSize, Allocator.Persistent, NativeArrayOptions.UninitializedMemory);
-    Positions = new NativeArray<Vector2>(poolSize, Allocator.Persistent, NativeArrayOptions.UninitializedMemory);
-    Rotations = new NativeArray<float>(poolSize, Allocator.Persistent, NativeArrayOptions.UninitializedMemory);
-    Speeds = new NativeArray<float>(poolSize, Allocator.Persistent, NativeArrayOptions.UninitializedMemory);
-    AngularSpeeds = new NativeArray<float>(poolSize, Allocator.Persistent, NativeArrayOptions.UninitializedMemory);
-    Colors = new NativeArray<Vector4>(poolSize, Allocator.Persistent, NativeArrayOptions.UninitializedMemory);
-    OldPositions = new NativeArray<Vector2>(poolSize, Allocator.Persistent, NativeArrayOptions.UninitializedMemory);
-    CollisionMasks = new NativeArray<int>(poolSize, Allocator.Persistent, NativeArrayOptions.UninitializedMemory);
-  }
+        internal JobHandle Update(JobHandle dependency = default(JobHandle))
+        {
+            var count = ActiveCount;
+            if (count <= 0) return dependency;
+            new NativeSlice<Vector2>(OldPositions, 0, count).CopyFrom(new NativeSlice<Vector2>(Positions, 0, count));
+            var move = new MoveDanmaku(this).ScheduleBatch(count, kBatchSize, dependency);
+            dependency = new BoundsCheckDanmaku(this).ScheduleBatch(count, kBatchSize, move);
+            dependency = new DestroyDanmaku(this).Schedule(dependency);
+            if (DanmakuCollider.ColliderCount > 0)
+            {
+                dependency = new CollideDanamku(this).Schedule(count, kBatchSize, dependency);
+            }
 
-  internal JobHandle Update(JobHandle dependency = default(JobHandle)) {
-    var count = ActiveCount;
-    if (count <= 0) return dependency;
-    new NativeSlice<Vector2>(OldPositions, 0, count).CopyFrom(new NativeSlice<Vector2>(Positions, 0, count));
-    var move = new MoveDanmaku(this).ScheduleBatch(count, kBatchSize, dependency);
-    dependency = new BoundsCheckDanmaku(this).ScheduleBatch(count, kBatchSize, move);
-    dependency = new DestroyDanmaku(this).Schedule(dependency);
-    if (DanmakuCollider.ColliderCount > 0) {
-      dependency = new CollideDanamku(this).Schedule(count, kBatchSize, dependency);
+            return dependency;
+        }
+
+        /// <summary>
+        /// Creates a new Danmaku from the pool.
+        /// </summary>
+        public Danmaku Get(DanmakuConfig config)
+        {
+            CheckCapacity(1);
+            var state = config.CreateState();
+            InitialStates[ActiveCount] = state;
+            Times[ActiveCount] = 0f;
+            var danmaku = new Danmaku(this, activeCountArray[0]++);
+            danmaku.ApplyState(state);
+            return danmaku;
+        }
+
+        /// <summary>
+        /// Retrieves a batch of new Danmaku from the pool.
+        /// </summary>
+        /// <param name="danmaku">an array of danmaku to write the values to.</param>
+        /// <param name="count">the number of danmaku to create. Must be less than or equal to the length of of danmaku.</param>
+        public void Get(Danmaku[] danmaku, int count)
+        {
+            CheckCapacity(count);
+            var activeCount = ActiveCount;
+            for (var i = 0; i < count; i++)
+            {
+                Times[activeCount + i] = 0f;
+                danmaku[i] = new Danmaku(this, activeCount + i);
+            }
+
+            activeCountArray[0] += count;
+        }
+
+        /// <summary>
+        /// Destroys all danmaku in the pool.
+        /// </summary>
+        public void Clear() => activeCountArray[0] = 0;
+
+        void CheckCapacity(int count)
+        {
+            if (ActiveCount + count > Capacity)
+            {
+                Resize();
+            }
+        }
+
+        void Resize()
+        {
+            Debug.LogWarning(
+                "A DanmakuPool is being resized due to inadequate capacity. This is expensive. Consider a higher starting pool size.");
+            Capacity *= kGrowthFactor;
+            Resize(ref InitialStates);
+            Resize(ref Times);
+            Resize(ref Positions);
+            Resize(ref Rotations);
+            Resize(ref Speeds);
+            Resize(ref AngularSpeeds);
+            Resize(ref Colors);
+            Resize(ref OldPositions);
+            Resize(ref CollisionMasks);
+        }
+
+        static void Resize<T>(ref NativeArray<T> array) where T : struct
+        {
+            var newArray = new NativeArray<T>(array.Length * kGrowthFactor, Allocator.Persistent,
+                NativeArrayOptions.UninitializedMemory);
+            var oldArray = array;
+            new NativeSlice<T>(newArray, 0, array.Length).CopyFrom(array);
+            array = newArray;
+            oldArray.Dispose();
+        }
+
+        /// <summary>
+        /// Disposes of the DanmakuPool. This destroys all of the bullets in the pool and
+        /// makes any operation on the pool invalid. Best used only when the pool is no longer
+        /// in use.
+        /// </summary>  
+        public void Dispose()
+        {
+            activeCountArray.Dispose();
+            InitialStates.Dispose();
+            Times.Dispose();
+            Positions.Dispose();
+            Rotations.Dispose();
+            Speeds.Dispose();
+            AngularSpeeds.Dispose();
+            Colors.Dispose();
+            OldPositions.Dispose();
+            CollisionMasks.Dispose();
+        }
+
+        /// <inheritdoc/>
+        public DanmakuEnumerator GetEnumerator() => new DanmakuEnumerator(this, 0, ActiveCount);
+
+        /// <inheritdoc/>
+        IEnumerator<Danmaku> IEnumerable<Danmaku>.GetEnumerator() => GetEnumerator();
+
+        /// <inheritdoc/>
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        internal void Destroy(Danmaku deactivate) => Times[deactivate.Id] = float.MinValue;
     }
-    return dependency;
-  }
 
-  /// <summary>
-  /// Creates a new Danmaku from the pool.
-  /// </summary>
-  public Danmaku Get(DanmakuConfig config) {
-    CheckCapacity(1);
-    var state = config.CreateState();
-    InitialStates[ActiveCount] = state;
-    Times[ActiveCount] = 0f;
-    var danmaku = new Danmaku(this, activeCountArray[0]++);
-    danmaku.ApplyState(state);
-    return danmaku;
-  } 
+    /// <summary>
+    /// An enumerator of <see cref="DanmakU.Danmaku"/>
+    /// </summary>
+    public struct DanmakuEnumerator : IEnumerator<Danmaku>
+    {
+        readonly DanmakuPool pool;
+        readonly int start;
+        readonly int end;
+        int index;
 
-  /// <summary>
-  /// Retrieves a batch of new Danmaku from the pool.
-  /// </summary>
-  /// <param name="danmaku">an array of danmaku to write the values to.</param>
-  /// <param name="count">the number of danmaku to create. Must be less than or equal to the length of of danmaku.</param>
-  public void Get(Danmaku[] danmaku, int count) {
-    CheckCapacity(count);
-    var activeCount = ActiveCount;
-    for (var i = 0; i < count; i++) {
-      Times[activeCount + i] = 0f;
-      danmaku[i] = new Danmaku(this, activeCount + i);
+        /// <inheritdoc/>
+        public Danmaku Current => new Danmaku(pool, index);
+
+        object IEnumerator.Current => Current;
+
+        internal DanmakuEnumerator(DanmakuPool pool, int start, int count)
+        {
+            this.pool = pool;
+            this.start = start;
+            this.end = start + count;
+            index = -1;
+        }
+
+        /// <inheritdoc/>
+        public bool MoveNext()
+        {
+            if (index < 0)
+            {
+                index = start;
+            }
+            else
+            {
+                index++;
+            }
+
+            return index < end;
+        }
+
+        /// <inheritdoc/>
+        public void Reset() => index = -1;
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+        }
     }
-    activeCountArray[0] += count;
-  }
-
-  /// <summary>
-  /// Destroys all danmaku in the pool.
-  /// </summary>
-  public void Clear() => activeCountArray[0] = 0;
-
-  void CheckCapacity(int count) {
-    if (ActiveCount + count > Capacity) {
-      Resize();
-    }
-  }
-
-  void Resize() {
-    Debug.LogWarning("A DanmakuPool is being resized due to inadequate capacity. This is expensive. Consider a higher starting pool size.");
-    Capacity *= kGrowthFactor;
-    Resize(ref InitialStates);
-    Resize(ref Times);
-    Resize(ref Positions);
-    Resize(ref Rotations);
-    Resize(ref Speeds);
-    Resize(ref AngularSpeeds);
-    Resize(ref Colors);
-    Resize(ref OldPositions);
-    Resize(ref CollisionMasks);
-  }
-
-  static void Resize<T>(ref NativeArray<T> array) where T : struct {
-    var newArray = new NativeArray<T>(array.Length * kGrowthFactor, Allocator.Persistent, NativeArrayOptions.UninitializedMemory);
-    var oldArray = array;
-    new NativeSlice<T>(newArray, 0, array.Length).CopyFrom(array);
-    array = newArray;
-    oldArray.Dispose();
-  }
-
-  /// <summary>
-  /// Disposes of the DanmakuPool. This destroys all of the bullets in the pool and
-  /// makes any operation on the pool invalid. Best used only when the pool is no longer
-  /// in use.
-  /// </summary>  
-  public void Dispose() {
-    activeCountArray.Dispose();
-    InitialStates.Dispose();
-    Times.Dispose();
-    Positions.Dispose();
-    Rotations.Dispose();
-    Speeds.Dispose();
-    AngularSpeeds.Dispose();
-    Colors.Dispose();
-    OldPositions.Dispose();
-    CollisionMasks.Dispose();
-  }
-
-  /// <inheritdoc/>
-  public DanmakuEnumerator GetEnumerator() => new DanmakuEnumerator(this, 0, ActiveCount);
-  /// <inheritdoc/>
-  IEnumerator<Danmaku> IEnumerable<Danmaku>.GetEnumerator() => GetEnumerator();
-  /// <inheritdoc/>
-  IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-
-  internal void Destroy(Danmaku deactivate) => Times[deactivate.Id] = float.MinValue;
-
-}
-
-/// <summary>
-/// An enumerator of <see cref="DanmakU.Danmaku"/>
-/// </summary>
-public struct DanmakuEnumerator : IEnumerator<Danmaku> {
-
-  readonly DanmakuPool pool;
-  readonly int start;
-  readonly int end;
-  int index;
-
-  /// <inheritdoc/>
-  public Danmaku Current => new Danmaku(pool, index);
-  object IEnumerator.Current => Current;
-
-  internal DanmakuEnumerator(DanmakuPool pool, int start, int count) {
-    this.pool =  pool;
-    this.start = start;
-    this.end = start + count;
-    index = -1;
-  }
-
-  /// <inheritdoc/>
-  public bool MoveNext() {
-    if (index < 0) {
-      index = start;
-    } else {
-      index++;
-    }
-    return index < end;
-  }
-
-  /// <inheritdoc/>
-  public void Reset() => index = -1;
-
-  /// <inheritdoc/>
-  public void Dispose() {}
-
-}
-
 }

--- a/Assets/DanmakU/Runtime/Core/DanmakuPool.cs
+++ b/Assets/DanmakU/Runtime/Core/DanmakuPool.cs
@@ -83,7 +83,7 @@ public class DanmakuPool : IEnumerable<Danmaku>, IDisposable {
   /// The recommended batch size for processing Danmaku in parallelizable jobs.
   /// </summary>
   /// <seealso cref="Unity.Jobs.IJobParallelFor"/>
-  public const int kBatchSize = 128;
+  public const int kBatchSize = 1024;
   const int kGrowthFactor = 2;
 
   /// <summary>
@@ -95,6 +95,10 @@ public class DanmakuPool : IEnumerable<Danmaku>, IDisposable {
   /// Gets the total capacity of the pool. Strictly greater than or equal to <see cref="ActiveCount"/>.
   /// </summary>
   public int Capacity { get; private set; }
+
+    public int TeamNo { get; set; }
+
+    public int Damage { get; set; }
 
   /// <summary>
   /// The radius of the collider used to calculate collisions with the bullets in the pool.

--- a/Assets/DanmakU/Runtime/Core/Rendering/DanmakuRenderer.cs
+++ b/Assets/DanmakU/Runtime/Core/Rendering/DanmakuRenderer.cs
@@ -73,7 +73,7 @@ internal class DanmakuRenderer : IDisposable {
 
     foreach (var set in sets) {
       var pool = set.Pool;
-      if (pool == null || pool.ActiveCount <= 0) return;
+      if (pool == null || pool.ActiveCount <= 0) continue;
 
       var srcPositions = (Vector2*)pool.Positions.GetUnsafeReadOnlyPtr();
       var srcRotations = (float*)pool.Rotations.GetUnsafeReadOnlyPtr();

--- a/Assets/DanmakU/Runtime/Core/Rendering/DanmakuRenderer.cs
+++ b/Assets/DanmakU/Runtime/Core/Rendering/DanmakuRenderer.cs
@@ -73,7 +73,7 @@ internal class DanmakuRenderer : IDisposable {
 
     foreach (var set in sets) {
       var pool = set.Pool;
-      if (pool == null || pool.ActiveCount <= 0) continue;
+      if (pool == null || pool.ActiveCount <= 0) return;
 
       var srcPositions = (Vector2*)pool.Positions.GetUnsafeReadOnlyPtr();
       var srcRotations = (float*)pool.Rotations.GetUnsafeReadOnlyPtr();

--- a/Assets/DanmakU/Runtime/DanmakuEmitter.cs
+++ b/Assets/DanmakU/Runtime/DanmakuEmitter.cs
@@ -20,7 +20,6 @@ namespace DanmakU
         public DanmakuSet set { get; private set; }
         public bool isFiring { get; set; }
 
-        //Editor OK   **WARNING** Do not access directly; use GetTeamNo and SetTeamNo
         public int TeamNo
         {
             get { return TeamNo;} 

--- a/Assets/DanmakU/Runtime/DanmakuEmitter.cs
+++ b/Assets/DanmakU/Runtime/DanmakuEmitter.cs
@@ -58,10 +58,15 @@ namespace DanmakU
             isFiring = true;
         }
 
-        /// <summary>
-        /// Update is called every frame, if the MonoBehaviour is enabled.
-        /// </summary>
-        void Update()
+		private void OnEnable()
+		{
+            timer = 0f;
+		}
+
+		/// <summary>
+		/// Update is called every frame, if the MonoBehaviour is enabled.
+		/// </summary>
+		void Update()
         {
             if (fireable == null) return;
             var deltaTime = Time.deltaTime;
@@ -87,4 +92,6 @@ namespace DanmakU
             }
         }
     }
+
+
 }

--- a/Assets/DanmakU/Runtime/DanmakuEmitter.cs
+++ b/Assets/DanmakU/Runtime/DanmakuEmitter.cs
@@ -5,88 +5,86 @@ using UnityEngine;
 
 namespace DanmakU
 {
-
-  [AddComponentMenu("DanmakU/Danmaku Emitter")]
-  public class DanmakuEmitter : DanmakuBehaviour
-  {
-
-    public DanmakuPrefab DanmakuType;
-
-    public Range Speed = 5f;
-    public Range AngularSpeed;
-    public Color Color = Color.white;
-    public Range FireRate = 5;
-    public float FrameRate;
-    public Arc Arc;
-    public Line Line;
-    public DanmakuSet set { get; private set; }
-    public bool isFiring { get; set; }
-
-    //Editor OK   **WARNING** Do not access directly; use GetTeamNo and SetTeamNo
-    public int TeamNo;
-
-    public int GetTeamNo()
+    [AddComponentMenu("DanmakU/Danmaku Emitter")]
+    public class DanmakuEmitter : DanmakuBehaviour
     {
-      return TeamNo;
-    }
+        public DanmakuPrefab DanmakuType;
 
-    public void SetTeamNo(int newTeam)
-    {
-      if (newTeam != TeamNo)
-        set.Pool.TeamNo = TeamNo = newTeam;
-    }
+        public Range Speed = 5f;
+        public Range AngularSpeed;
+        public Color Color = Color.white;
+        public Range FireRate = 5;
+        public float FrameRate;
+        public Arc Arc;
+        public Line Line;
+        public DanmakuSet set { get; private set; }
+        public bool isFiring { get; set; }
 
-    float timer;
+        //Editor OK   **WARNING** Do not access directly; use GetTeamNo and SetTeamNo
+        public int TeamNo;
 
-    DanmakuConfig config;
-    IFireable fireable;
-
-    /// <summary>
-    /// Start is called on the frame when a script is enabled just before
-    /// any of the Update methods is called the first time.
-    /// </summary>
-    void Start()
-    {
-      if (DanmakuType == null)
-      {
-        Debug.LogWarning($"Emitter doesn't have a valid DanmakuPrefab", this);
-        return;
-      }
-
-      set = CreateSet(DanmakuType);
-      set.Pool.TeamNo = TeamNo;
-      set.AddModifiers(GetComponents<IDanmakuModifier>());
-      fireable = Arc.Of(Line).Of(set);
-      isFiring = true;
-    }
-
-    /// <summary>
-    /// Update is called every frame, if the MonoBehaviour is enabled.
-    /// </summary>
-    void Update()
-    {
-      if (fireable == null) return;
-      var deltaTime = Time.deltaTime;
-      if (FrameRate > 0)
-      {
-        deltaTime = 1f / FrameRate;
-      }
-
-      timer -= deltaTime;
-      if (!isFiring) return;
-      if (timer < 0)
-      {
-        config = new DanmakuConfig
+        public int GetTeamNo()
         {
-          Position = transform.position,
-          Rotation = transform.rotation.eulerAngles.z * Mathf.Deg2Rad,
-          Speed = Speed,
-          AngularSpeed = AngularSpeed,
-          Color = Color
-        };
-        fireable.Fire(config);
-        timer = 1f / FireRate.GetValue();
-      }
+            return TeamNo;
+        }
+
+        public void SetTeamNo(int newTeam)
+        {
+            if (newTeam != TeamNo)
+                set.Pool.TeamNo = TeamNo = newTeam;
+        }
+
+        float timer;
+
+        DanmakuConfig config;
+        IFireable fireable;
+
+        /// <summary>
+        /// Start is called on the frame when a script is enabled just before
+        /// any of the Update methods is called the first time.
+        /// </summary>
+        void Start()
+        {
+            if (DanmakuType == null)
+            {
+                Debug.LogWarning($"Emitter doesn't have a valid DanmakuPrefab", this);
+                return;
+            }
+
+            set = CreateSet(DanmakuType);
+            set.Pool.TeamNo = TeamNo;
+            set.AddModifiers(GetComponents<IDanmakuModifier>());
+            fireable = Arc.Of(Line).Of(set);
+            isFiring = true;
+        }
+
+        /// <summary>
+        /// Update is called every frame, if the MonoBehaviour is enabled.
+        /// </summary>
+        void Update()
+        {
+            if (fireable == null) return;
+            var deltaTime = Time.deltaTime;
+            if (FrameRate > 0)
+            {
+                deltaTime = 1f / FrameRate;
+            }
+
+            timer -= deltaTime;
+            if (!isFiring) return;
+            if (timer < 0)
+            {
+                config = new DanmakuConfig
+                {
+                    Position = transform.position,
+                    Rotation = transform.rotation.eulerAngles.z * Mathf.Deg2Rad,
+                    Speed = Speed,
+                    AngularSpeed = AngularSpeed,
+                    Color = Color
+                };
+                fireable.Fire(config);
+                timer = 1f / FireRate.GetValue();
+            }
+        }
     }
-  }
 }

--- a/Assets/DanmakU/Runtime/DanmakuEmitter.cs
+++ b/Assets/DanmakU/Runtime/DanmakuEmitter.cs
@@ -18,29 +18,19 @@ public class DanmakuEmitter : DanmakuBehaviour {
   public Arc Arc;
   public Line Line;
   public DanmakuSet set { get; private set; }
-  public int Damage = 10;
-  
-
- // private bool _isFiring;
   public bool isFiring { get; set; }
 
-    //Editor OK   **WARNING** Do not access directly; use GetTeamNo and SetTeamNo
-    public int TeamNo;
-    public int GetTeamNo()
-    {
-      return TeamNo;
-    }
-    public void SetTeamNo(int newTeam)
-    {
-      if (newTeam != TeamNo)
-        set.Pool.TeamNo = TeamNo = newTeam;
-    }
-    
-  /*{
-      get { return _isFiring; }
-      set { timer = 0; _isFiring = value; }
-  }*/
-  
+  //Editor OK   **WARNING** Do not access directly; use GetTeamNo and SetTeamNo
+  public int TeamNo;
+  public int GetTeamNo()
+  {
+    return TeamNo;
+  }
+  public void SetTeamNo(int newTeam)
+  {
+    if (newTeam != TeamNo)
+      set.Pool.TeamNo = TeamNo = newTeam;
+  }
             
   float timer;
 

--- a/Assets/DanmakU/Runtime/DanmakuEmitter.cs
+++ b/Assets/DanmakU/Runtime/DanmakuEmitter.cs
@@ -20,10 +20,15 @@ namespace DanmakU
         public DanmakuSet set { get; private set; }
         public bool isFiring { get; set; }
 
-        public int TeamNo
+        public int TeamNo;
+        public int GetTeamNo()
         {
-            get { return TeamNo;} 
-            set { if (value != TeamNo) set.Pool.TeamNo = TeamNo = value; }
+            return TeamNo;
+        }
+
+        public void SetTeamNo(int value)
+        {
+            if (value != TeamNo) set.Pool.TeamNo = TeamNo = value;
         }
         
         float timer;

--- a/Assets/DanmakU/Runtime/DanmakuEmitter.cs
+++ b/Assets/DanmakU/Runtime/DanmakuEmitter.cs
@@ -58,11 +58,11 @@ namespace DanmakU
             isFiring = true;
         }
 
-		private void OnEnable()
-		{
+        private void OnEnable()
+        {
             timer = 0f;
-		}
-
+        }
+        
 		/// <summary>
 		/// Update is called every frame, if the MonoBehaviour is enabled.
 		/// </summary>

--- a/Assets/DanmakU/Runtime/DanmakuEmitter.cs
+++ b/Assets/DanmakU/Runtime/DanmakuEmitter.cs
@@ -27,7 +27,6 @@ namespace DanmakU
             set { if (value != TeamNo) set.Pool.TeamNo = TeamNo = value; }
         }
         
-
         float timer;
 
         DanmakuConfig config;

--- a/Assets/DanmakU/Runtime/DanmakuEmitter.cs
+++ b/Assets/DanmakU/Runtime/DanmakuEmitter.cs
@@ -21,18 +21,12 @@ namespace DanmakU
         public bool isFiring { get; set; }
 
         //Editor OK   **WARNING** Do not access directly; use GetTeamNo and SetTeamNo
-        public int TeamNo;
-
-        public int GetTeamNo()
+        public int TeamNo
         {
-            return TeamNo;
+            get { return TeamNo;} 
+            set { if (value != TeamNo) set.Pool.TeamNo = TeamNo = value; }
         }
-
-        public void SetTeamNo(int newTeam)
-        {
-            if (newTeam != TeamNo)
-                set.Pool.TeamNo = TeamNo = newTeam;
-        }
+        
 
         float timer;
 

--- a/Assets/DanmakU/Runtime/DanmakuEmitter.cs
+++ b/Assets/DanmakU/Runtime/DanmakuEmitter.cs
@@ -36,16 +36,16 @@ namespace DanmakU
         set.Pool.TeamNo = TeamNo = newTeam;
     }
 
-    protected float timer;
+    float timer;
 
-    protected DanmakuConfig config;
-    protected IFireable fireable;
+    DanmakuConfig config;
+    IFireable fireable;
 
     /// <summary>
     /// Start is called on the frame when a script is enabled just before
     /// any of the Update methods is called the first time.
     /// </summary>
-    protected void Start()
+    void Start()
     {
       if (DanmakuType == null)
       {

--- a/Assets/DanmakU/Runtime/DanmakuEmitter.cs
+++ b/Assets/DanmakU/Runtime/DanmakuEmitter.cs
@@ -18,15 +18,15 @@ public class DanmakuEmitter : DanmakuBehaviour {
   public Arc Arc;
   public Line Line;
 
-  float timer;
-  DanmakuConfig config;
-  IFireable fireable;
+  protected float timer;
+  protected DanmakuConfig config;
+  protected IFireable fireable;
 
   /// <summary>
   /// Start is called on the frame when a script is enabled just before
   /// any of the Update methods is called the first time.
   /// </summary>
-  void Start() {
+  protected void Start() {
     if (DanmakuType == null) {
       Debug.LogWarning($"Emitter doesn't have a valid DanmakuPrefab", this);
       return;

--- a/Assets/DanmakU/Runtime/DanmakuEmitter.cs
+++ b/Assets/DanmakU/Runtime/DanmakuEmitter.cs
@@ -17,8 +17,33 @@ public class DanmakuEmitter : DanmakuBehaviour {
   public float FrameRate;
   public Arc Arc;
   public Line Line;
+  public DanmakuSet set { get; private set; }
+  public int Damage = 10;
+  
 
+ // private bool _isFiring;
+  public bool isFiring { get; set; }
+
+    //Editor OK   **WARNING** Do not access directly; use GetTeamNo and SetTeamNo
+    public int TeamNo;
+    public int GetTeamNo()
+    {
+      return TeamNo;
+    }
+    public void SetTeamNo(int newTeam)
+    {
+      if (newTeam != TeamNo)
+        set.Pool.TeamNo = TeamNo = newTeam;
+    }
+    
+  /*{
+      get { return _isFiring; }
+      set { timer = 0; _isFiring = value; }
+  }*/
+  
+            
   float timer;
+
   DanmakuConfig config;
   IFireable fireable;
 
@@ -31,9 +56,11 @@ public class DanmakuEmitter : DanmakuBehaviour {
       Debug.LogWarning($"Emitter doesn't have a valid DanmakuPrefab", this);
       return;
     }
-    var set = CreateSet(DanmakuType);
+    set = CreateSet(DanmakuType);
+    set.Pool.TeamNo = TeamNo;
     set.AddModifiers(GetComponents<IDanmakuModifier>());
     fireable = Arc.Of(Line).Of(set);
+    isFiring = true;
   }
 
   /// <summary>
@@ -46,6 +73,7 @@ public class DanmakuEmitter : DanmakuBehaviour {
       deltaTime = 1f / FrameRate;
     }
     timer -= deltaTime;
+    if (!isFiring) return;
     if (timer < 0) {
       config = new DanmakuConfig {
         Position = transform.position,


### PR DESCRIPTION
If you disable a DanmakuEmitter Component while the game is running, rendering for all Danmaku breaks. The one-line change fixes this.
https://github.com/james7132/DanmakU/issues/39